### PR TITLE
Added a way to auto update av definitions

### DIFF
--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -200,7 +200,7 @@ def clean_all(config: str, verbose: bool):
 @cli.command("serve")
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.option("--update-interval-seconds", "-u",type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
+@click.option("--update-interval-seconds", "-U", type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
 @click.argument("port", type=int, required=False, default=8000)
 def serve(port: int, config: str, verbose: bool, update_interval_seconds: int):
     """

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -39,7 +39,7 @@ import coloredlogs
 from http.server import HTTPServer
 from RangeHTTPServer import RangeRequestHandler
 
-import auto_updater
+from cvdupdate import auto_updater
 import pkg_resources
 from cvdupdate.cvdupdate import CVDUpdate
 
@@ -200,8 +200,9 @@ def clean_all(config: str, verbose: bool):
 @cli.command("serve")
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--update-interval-seconds", "-u",type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
 @click.argument("port", type=int, required=False, default=8000)
-def serve(port: int, config: str, verbose: bool):
+def serve(port: int, config: str, verbose: bool, update_interval_seconds: int):
     """
     Serve up the database directory. Not a production quality server.
     Intended for testing purposes.
@@ -209,7 +210,7 @@ def serve(port: int, config: str, verbose: bool):
     m = CVDUpdate(config=config, verbose=verbose)
     os.chdir(str(m.db_dir))
     m.logger.info(f"Serving up {m.db_dir} on localhost:{port}...")
-    auto_updater.start()
+    auto_updater.start(update_interval_seconds)
 
     RangeRequestHandler.protocol_version = 'HTTP/1.0'
     # TODO(danvk): pick a random, available port

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -39,7 +39,7 @@ import coloredlogs
 from http.server import HTTPServer
 from RangeHTTPServer import RangeRequestHandler
 
-
+import auto_updater
 import pkg_resources
 from cvdupdate.cvdupdate import CVDUpdate
 
@@ -209,6 +209,7 @@ def serve(port: int, config: str, verbose: bool):
     m = CVDUpdate(config=config, verbose=verbose)
     os.chdir(str(m.db_dir))
     m.logger.info(f"Serving up {m.db_dir} on localhost:{port}...")
+    auto_updater.start()
 
     RangeRequestHandler.protocol_version = 'HTTP/1.0'
     # TODO(danvk): pick a random, available port

--- a/cvdupdate/auto_updater.py
+++ b/cvdupdate/auto_updater.py
@@ -2,21 +2,23 @@ from threading import Event, Thread
 
 from cvdupdate.cvdupdate import CVDUpdate
 
-# one time per day
-WAIT_TIME_SECONDS = 24 * 60 * 60
+def start(interval: int) -> None:
+    '''Spawns a thread to update the AV db after "interval" seconds
+    :param interval: the interval in seconds between 2 updates of the db
+    '''
+    if interval > 0:
+        Thread(target=_update, daemon=True, args=[interval]).start()
 
 
-def start() -> None:
-    """Spawns a thread to update the AV db periodically"""
-    Thread(target=_update, daemon=True).start()
+def _update(interval: int) -> None:
+    '''Don't call this directly
 
-
-def _update() -> None:
-    """Don't call this directly
-    Updates the AV db every day when it was started"""
+    Updates the AV db after every "interval" seconds when it was started
+    :param interval: the interval in seconds between 2 updates of the db
+    '''
     ticker = Event()
     m = CVDUpdate()
-    while not ticker.wait(WAIT_TIME_SECONDS):
+    while not ticker.wait(interval):
         errors = m.db_update(debug_mode=True)
         if errors > 0:
-            m.logger.error(f"Failed to fetch updates from ClamAV databases")
+            m.logger.error("Failed to fetch updates from ClamAV databases")

--- a/cvdupdate/auto_updater.py
+++ b/cvdupdate/auto_updater.py
@@ -3,21 +3,22 @@ from threading import Event, Thread
 from cvdupdate.cvdupdate import CVDUpdate
 
 def start(interval: int) -> None:
-    '''Spawns a thread to update the AV db after "interval" seconds
+    """Spawn a thread to update the AV db after "interval" seconds
     :param interval: the interval in seconds between 2 updates of the db
-    '''
+    """
     if interval > 0:
         Thread(target=_update, daemon=True, args=[interval]).start()
 
 
 def _update(interval: int) -> None:
-    '''Don't call this directly
+    """Don't call this directly
 
     Updates the AV db after every "interval" seconds when it was started
     :param interval: the interval in seconds between 2 updates of the db
-    '''
+    """
     ticker = Event()
     m = CVDUpdate()
+    m.logger.info(f"Updating the database every {interval} seconds")
     while not ticker.wait(interval):
         errors = m.db_update(debug_mode=True)
         if errors > 0:

--- a/cvdupdate/auto_updater.py
+++ b/cvdupdate/auto_updater.py
@@ -1,0 +1,22 @@
+from threading import Event, Thread
+
+from cvdupdate.cvdupdate import CVDUpdate
+
+# one time per day
+WAIT_TIME_SECONDS = 24 * 60 * 60
+
+
+def start() -> None:
+    """Spawns a thread to update the AV db periodically"""
+    Thread(target=_update, daemon=True).start()
+
+
+def _update() -> None:
+    """Don't call this directly
+    Updates the AV db every day when it was started"""
+    ticker = Event()
+    m = CVDUpdate()
+    while not ticker.wait(WAIT_TIME_SECONDS):
+        errors = m.db_update(debug_mode=True)
+        if errors > 0:
+            m.logger.error(f"Failed to fetch updates from ClamAV databases")


### PR DESCRIPTION
Runs a simple timer in a separate thread and calls an update every 24 hours.

Improvement paths: Set an hour for the start of the timer (so that it runs more like a cron), hook this into the CLI to customize timer.

Relates to DT-4019